### PR TITLE
Allow users to log their work hours for the day

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,6 +12,7 @@ This is a Ruby command-line tool for calculating the total work hours, break hou
 - Return net work hours after subtracting break times.
 - Return net break hours.
 - Support for csv import or export.
+- Log your work hours for the day.
 
 ## Installation
 
@@ -23,6 +24,14 @@ gem install work_hours_calculator
 To calculate your work hours, run the following command:
 ```bash
 work_calculator -s "9:30:00 AM" -e "7:00:00 PM" -b "12:49:00 PM-1:26:00 PM,3:42:00 PM-4:35:00 PM"
+```
+
+### Expected Output
+```bash
+Total Work Decimal Hours: 9.5 hours
+Total Break Decimal Hours: 1.5 hours
+Total Break Hours: 1:30 minutes
+Net Work Decimal Hours: 8.0 hours
 ```
 
 ## Using CSV Input
@@ -40,13 +49,33 @@ You can export the results to a CSV file by specifying the --csv-output option:
 ```bash
 work_calculator -s "9:30:00 AM" -e "7:00:00 PM" -b "12:49:00 PM-1:26:00 PM,3:42:00 PM-4:35:00 PM" --csv-output path/to/your/output.csv
 ```
-
-# Expected Output
+## Logging Work Hours for the Day
+You can log your work hours throughout the day, much like a diary of your work. To log your work, run the following command:
 ```bash
-Total Work Decimal Hours: 9.5 hours
-Total Break Decimal Hours: 1.5 hours
-Total Break Hours: 1:30 minutes
-Net Work Decimal Hours: 8.0 hours
+work_calculator --log some-description-goes-here
+```
+Example:
+```bash
+work_calculator --log "working on an interesting project"
+# > Logged work: 2025-02-22 19:47:24 - working on an interesting project
+
+work_calculator --log "break"
+# > Logged work: 2025-02-22 19:48:11 - break
+
+work_calculator --log "end"
+# > Logged work: 2025-02-22 19:50:01 - end
+```
+Please note of the system keywords for the description: 
+- "break" : considered the record log as a break
+- "end" : considered the record log as finished or has ended work for the day.
+
+### Calculate the hours from your work log
+```bash
+work_calculator --calculate-log "2025-02-22"
+# > Total Work Decimal Hours: 3.2 hours
+# > Total Break Decimal Hours: 2.15 hours
+# > Total Break Hours: 2:09 minutes
+# > Net Work Decimal Hours: 1.05 hours
 ```
 
 ## Usage
@@ -60,7 +89,12 @@ Run the script from the command line with the required options for start time, e
 | -b or --breaks | Specifies break periods in comma-separated start_time-end_time format | `-b "12:49:00 PM-1:26:00 PM,3:42:00 PM-4:35:00 PM"` |
 | --csv-input | Specifies the CSV input file | `--csv-input path/to/your/input.csv`s |
 | --csv-output | Specifies the CSV output file | `--csv-output path/to/your/output.csv` |
+| --log DESCRIPTION | Log work with description | `--log "working on a project"` |
+| --log-dir DIRECTORY | Specify a directory to store log files | `--lod-dir` <br><br>or export it as an ENV variable so you don't have to specify the directory arg everytime. <br> `export WORK_HOURS_LOG_DIR="/some/path"`|
+| --calculate-log DATE | Calculate hours from the log file for the specified date (e.g., '2023-10-01') | `--calculate-log 2025-02-01` |
 | -h or --help | Displays help instructions | `-h` |
+
+
 
 ## TODOS
 - Add support for overtimes

--- a/bin/work_calculator
+++ b/bin/work_calculator
@@ -4,21 +4,28 @@
 require_relative '../lib/work_hours_calculator'
 require_relative '../lib/work_hours_calculator/parser'
 require_relative '../lib/work_hours_calculator/csv_handler'
+require_relative '../lib/work_hours_calculator/logger'
 
 options = WorkHoursCalculator::Parser.parse_options
 
-if options[:csv_input]
-  data = WorkHoursCalculator::CSVHandler.import(options[:csv_input])
-  results = WorkHoursCalculator.calculate(data[:work_start], data[:work_end], data[:breaks])
+if options[:log]
+  WorkHoursCalculator::Logger.log_work(options[:description])
 else
-  results = WorkHoursCalculator.calculate(options[:start_time], options[:end_time], options[:breaks])
-end
+  if options[:calculate_log]
+    results = WorkHoursCalculator.calculate_hours_from_log(options[:log_date])
+  elsif options[:csv_input]
+    data = WorkHoursCalculator::CSVHandler.import(options[:csv_input])
+    results = WorkHoursCalculator.calculate(data[:work_start], data[:work_end], data[:breaks])
+  else
+    results = WorkHoursCalculator.calculate(options[:start_time], options[:end_time], options[:breaks])
+  end
 
-if options[:csv_output]
-  WorkHoursCalculator::CSVHandler.export(options[:csv_output], results)
-else
-  puts "Total Work Decimal Hours: #{results[:total_work_decimal_hours].round(2)} hours"
-  puts "Total Break Decimal Hours: #{results[:total_break_decimal_hours].round(2)} hours"
-  puts "Total Break Hours: #{results[:total_break_hours]} minutes"
-  puts "Net Work Decimal Hours: #{results[:net_work_decimal_hours].round(2)} hours"
+  if options[:csv_output]
+    WorkHoursCalculator::CSVHandler.export(options[:csv_output], results)
+  else
+    puts "Total Work Decimal Hours: #{results[:total_work_decimal_hours].round(2)} hours"
+    puts "Total Break Decimal Hours: #{results[:total_break_decimal_hours].round(2)} hours"
+    puts "Total Break Hours: #{results[:total_break_hours]} minutes"
+    puts "Net Work Decimal Hours: #{results[:net_work_decimal_hours].round(2)} hours"
+  end
 end

--- a/lib/work_hours_calculator.rb
+++ b/lib/work_hours_calculator.rb
@@ -9,4 +9,9 @@ module WorkHoursCalculator
   def self.calculate(work_start, work_end, breaks)
     WorkHoursCalculator::Calculate.new(work_start, work_end, breaks).execute
   end
+
+  def self.calculate_hours_from_log(date)
+    results = WorkHoursCalculator::Logger.get_hours_from_log(date)
+    WorkHoursCalculator::Calculate.new(results[:work_start], results[:work_end], results[:breaks]).execute
+  end
 end

--- a/lib/work_hours_calculator.rb
+++ b/lib/work_hours_calculator.rb
@@ -2,6 +2,7 @@
 
 require_relative "work_hours_calculator/version"
 require_relative "work_hours_calculator/calculate"
+require_relative "work_hours_calculator/logger"
 
 module WorkHoursCalculator
   class Error < StandardError; end

--- a/lib/work_hours_calculator/logger.rb
+++ b/lib/work_hours_calculator/logger.rb
@@ -5,8 +5,9 @@ require "time"
 module WorkHoursCalculator
   class Logger
     DEFAULT_LOG_DIR = File.join(Dir.home, "work_hours_logs")
+    LOG_DIR = ENV["WORK_HOURS_LOG_DIR"] || DEFAULT_LOG_DIR
 
-    def self.log_work(description, log_dir = DEFAULT_LOG_DIR)
+    def self.log_work(description, log_dir = LOG_DIR)
       Dir.mkdir(log_dir) unless Dir.exist?(log_dir)
       log_file = File.join(log_dir, "#{Date.today}.csv")
 

--- a/lib/work_hours_calculator/logger.rb
+++ b/lib/work_hours_calculator/logger.rb
@@ -3,23 +3,44 @@ require "date"
 require "time"
 
 module WorkHoursCalculator
+  class InvalidFile < StandardError; end
+
+  class InvalidDir < StandardError; end
+
+  class InvalidRecord < StandardError; end
+
+  class MissingRecord < StandardError; end
+
   class Logger
     DEFAULT_LOG_DIR = File.join(Dir.home, "work_hours_logs")
     LOG_DIR = ENV["WORK_HOURS_LOG_DIR"] || DEFAULT_LOG_DIR
 
     def self.log_work(description, log_dir = LOG_DIR)
-      Dir.mkdir(log_dir) unless Dir.exist?(log_dir)
+      raise InvalidRecord, "Description cannot be empty" if description.nil? || description.strip.empty?
+
+      begin
+        Dir.mkdir(log_dir) unless Dir.exist?(log_dir)
+      rescue SystemCallError => e
+        raise InvalidDir, "Failed to create log directory: #{e.message}"
+      end
+
       log_file = File.join(log_dir, "#{Date.today}.csv")
 
-      CSV.open(log_file, "a") do |csv|
-        time = Time.now.strftime("%Y-%m-%d %H:%M:%S")
-        csv << [time, description]
+      begin
+        CSV.open(log_file, "a") do |csv|
+          time = Time.now.strftime("%Y-%m-%d %H:%M:%S")
+          csv << [time, description]
+        end
+      rescue SystemCallError => e
+        raise InvalidFile, "Failed to write to log file: #{e.message}"
       end
 
       puts "Logged work: #{Time.now.strftime("%Y-%m-%d %H:%M:%S")} - #{description}"
     end
 
     def self.get_hours_from_log(date, log_dir = DEFAULT_LOG_DIR)
+      raise InvalidRecord, "Date cannot be nil" if date.nil?
+
       log_file = File.join(log_dir, "#{date}.csv")
       unless File.exist?(log_file)
         puts "Log file for #{date} not found."
@@ -30,8 +51,14 @@ module WorkHoursCalculator
         {time: Time.parse(row[0]), description: row[1].strip}
       end
 
-      work_start = entries.find { |entry| entry[:description].downcase != "break" }[:time]
-      work_end = entries.reverse.find { |entry| entry[:description].downcase == "end" }[:time]
+      work_start = entries.find { |entry| entry[:description].downcase != "break" && entry[:description].downcase != "end" }
+      work_end = entries.reverse.find { |entry| entry[:description].downcase == "end" }
+
+      raise MissingRecord, "Work start record not found" if work_start.nil?
+      raise MissingRecord, "Work end record not found" if work_end.nil?
+
+      work_start_time = work_start[:time]
+      work_end_time = work_end[:time]
 
       breaks = []
       break_start = nil
@@ -46,8 +73,8 @@ module WorkHoursCalculator
       end
 
       {
-        work_start: work_start.strftime("%I:%M:%S %p"),
-        work_end: work_end.strftime("%I:%M:%S %p"),
+        work_start: work_start_time.strftime("%I:%M:%S %p"),
+        work_end: work_end_time.strftime("%I:%M:%S %p"),
         breaks: breaks.map { |start, end_time| [start.strftime("%I:%M:%S %p"), end_time.strftime("%I:%M:%S %p")] }
       }
     end

--- a/lib/work_hours_calculator/logger.rb
+++ b/lib/work_hours_calculator/logger.rb
@@ -1,0 +1,54 @@
+require "csv"
+require "date"
+require "time"
+
+module WorkHoursCalculator
+  class Logger
+    DEFAULT_LOG_DIR = File.join(Dir.home, "work_hours_logs")
+
+    def self.log_work(description, log_dir = DEFAULT_LOG_DIR)
+      Dir.mkdir(log_dir) unless Dir.exist?(log_dir)
+      log_file = File.join(log_dir, "#{Date.today}.csv")
+
+      CSV.open(log_file, "a") do |csv|
+        time = Time.now.strftime("%Y-%m-%d %H:%M:%S")
+        csv << [time, description]
+      end
+
+      puts "Logged work: #{Time.now.strftime("%Y-%m-%d %H:%M:%S")} - #{description}"
+    end
+
+    def self.get_hours_from_log(date, log_dir = DEFAULT_LOG_DIR)
+      log_file = File.join(log_dir, "#{date}.csv")
+      unless File.exist?(log_file)
+        puts "Log file for #{date} not found."
+        exit 1
+      end
+
+      entries = CSV.read(log_file, headers: false).map do |row|
+        {time: Time.parse(row[0]), description: row[1].strip}
+      end
+
+      work_start = entries.find { |entry| entry[:description].downcase != "break" }[:time]
+      work_end = entries.reverse.find { |entry| entry[:description].downcase == "end" }[:time]
+
+      breaks = []
+      break_start = nil
+
+      entries.each do |entry|
+        if entry[:description].downcase == "break" || entry[:description].downcase == "end"
+          break_start ||= entry[:time]
+        elsif break_start
+          breaks << [break_start, entry[:time]]
+          break_start = nil
+        end
+      end
+
+      {
+        work_start: work_start.strftime("%I:%M:%S %p"),
+        work_end: work_end.strftime("%I:%M:%S %p"),
+        breaks: breaks.map { |start, end_time| [start.strftime("%I:%M:%S %p"), end_time.strftime("%I:%M:%S %p")] }
+      }
+    end
+  end
+end

--- a/lib/work_hours_calculator/parser.rb
+++ b/lib/work_hours_calculator/parser.rb
@@ -15,15 +15,29 @@ module WorkHoursCalculator
         opts.on("-b", "--breaks x,y", Array, "Break periods as comma-separated pairs (e.g., '12:49:00 PM-1:26:00 PM,3:42:00 PM-4:35:00 PM')") { |v| options[:breaks] = v.map { |pair| pair.split("-") } }
         opts.on("--csv-input FILE", "CSV input file") { |v| options[:csv_input] = v }
         opts.on("--csv-output FILE", "CSV output file") { |v| options[:csv_output] = v }
+        opts.on("--log DESCRIPTION", "Log work with description") { |v|
+          options[:log] = true
+          options[:description] = v
+        }
+        opts.on("--log-dir DIRECTORY", "Directory to store log files") { |v| options[:log_dir] = v }
+        opts.on("--calculate-log DATE", "Calculate hours from the log file for the specified date (e.g., '2023-10-01')") { |v|
+          options[:calculate_log] = true
+          options[:log_date] = v
+        }
         opts.on("-h", "--help", "Show help") {
           puts opts
           exit
         }
       end.parse!(args, into: options)
 
-      if options[:csv_input].nil? && (options[:start_time].nil? || options[:end_time].nil? || options[:breaks].nil?)
+      if (options[:csv_input].nil? && options[:log].nil? && options[:calculate_log].nil?) && (options[:start_time].nil? || options[:end_time].nil? || options[:breaks].nil?)
         puts "Please provide start time, end time, and break times, or a CSV input file."
         exit
+      end
+
+      if options[:log] && options[:description].nil?
+        puts "Error: Description is required when logging work hours."
+        exit 1
       end
 
       options

--- a/test/lib/work_hours_calculator/logger_test.rb
+++ b/test/lib/work_hours_calculator/logger_test.rb
@@ -1,0 +1,112 @@
+require_relative "../../test_helper"
+require "minitest/autorun"
+require "fileutils"
+require_relative "../../../lib/work_hours_calculator/logger"
+
+class WorkHoursCalculator::LoggerTest < Minitest::Test
+  def setup
+    @log_dir = File.join(Dir.pwd, "test/test_logs")
+    FileUtils.rm_rf(@log_dir) if Dir.exist?(@log_dir)
+  end
+
+  def teardown
+    FileUtils.rm_rf(@log_dir) if Dir.exist?(@log_dir)
+  end
+
+  def test_log_work_creates_log_file
+    description = "Started working on project X"
+    WorkHoursCalculator::Logger.log_work(description, @log_dir)
+
+    log_file = File.join(@log_dir, "#{Date.today}.csv")
+    assert File.exist?(log_file), "Log file should be created"
+
+    log_content = CSV.read(log_file)
+    assert_equal 1, log_content.size, "Log file should have one entry"
+    assert_equal description, log_content[0][1], "Log entry should match the description"
+  end
+
+  def test_log_work_with_empty_description
+    assert_raises(WorkHoursCalculator::InvalidRecord) do
+      WorkHoursCalculator::Logger.log_work("", @log_dir)
+    end
+  end
+
+  def test_log_work_creates_log_directory
+    description = "Started working on project Y"
+    WorkHoursCalculator::Logger.log_work(description, @log_dir)
+
+    assert Dir.exist?(@log_dir), "Log directory should be created"
+  end
+
+  def test_log_work_handles_system_call_error
+    log_dir = "/root/test_logs"
+    description = "Started working on project Z"
+
+    assert_raises(WorkHoursCalculator::InvalidDir) do
+      WorkHoursCalculator::Logger.log_work(description, log_dir)
+    end
+  end
+
+  def test_get_hours_from_log
+    FileUtils.mkdir_p(@log_dir)
+    log_file = File.join(@log_dir, "#{Date.today}.csv")
+    CSV.open(log_file, "w") do |csv|
+      csv << ["2025-02-01 09:00:00", "Started working"]
+      csv << ["2025-02-01 12:00:00", "Break"]
+      csv << ["2025-02-01 13:00:00", "Back to work"]
+      csv << ["2025-02-01 17:00:00", "End"]
+    end
+    result = WorkHoursCalculator::Logger.get_hours_from_log(Date.today, @log_dir)
+    assert_equal "09:00:00 AM", result[:work_start]
+    assert_equal "05:00:00 PM", result[:work_end]
+    assert_equal 1, result[:breaks].size
+    assert_equal "12:00:00 PM", result[:breaks][0][0]
+    assert_equal "01:00:00 PM", result[:breaks][0][1]
+  end
+
+  def test_get_hours_from_log_file_not_found
+    assert_raises(SystemExit) do
+      WorkHoursCalculator::Logger.get_hours_from_log(Date.today, @log_dir)
+    end
+  end
+
+  def test_get_hours_from_log_missing_work_start
+    FileUtils.mkdir_p(@log_dir)
+    log_file = File.join(@log_dir, "#{Date.today}.csv")
+    CSV.open(log_file, "w") do |csv|
+      csv << [Time.now.strftime("%Y-%m-%d %H:%M:%S"), "break"]
+      csv << [(Time.now + 3600).strftime("%Y-%m-%d %H:%M:%S"), "End"]
+    end
+
+    assert_raises(WorkHoursCalculator::MissingRecord) do
+      WorkHoursCalculator::Logger.get_hours_from_log(Date.today, @log_dir)
+    end
+  end
+
+  def test_get_hours_from_log_missing_work_end
+    FileUtils.mkdir_p(@log_dir)
+    log_file = File.join(@log_dir, "#{Date.today}.csv")
+    CSV.open(log_file, "w") do |csv|
+      csv << [Time.now.strftime("%Y-%m-%d %H:%M:%S"), "Started working"]
+      csv << [(Time.now + 3600).strftime("%Y-%m-%d %H:%M:%S"), "Break"]
+    end
+
+    assert_raises(WorkHoursCalculator::MissingRecord) do
+      WorkHoursCalculator::Logger.get_hours_from_log(Date.today, @log_dir)
+    end
+  end
+
+  def test_get_hours_from_log_missing_break
+    FileUtils.mkdir_p(@log_dir)
+    log_file = File.join(@log_dir, "#{Date.today}.csv")
+    CSV.open(log_file, "w") do |csv|
+      csv << ["2025-02-01 09:00:00", "Started working"]
+      csv << ["2025-02-01 17:00:00", "End"]
+    end
+
+    result = WorkHoursCalculator::Logger.get_hours_from_log(Date.today, @log_dir)
+    assert_equal "09:00:00 AM", result[:work_start]
+    assert_equal "05:00:00 PM", result[:work_end]
+    assert_equal 0, result[:breaks].size
+  end
+end

--- a/test/lib/work_hours_calculator/parser_test.rb
+++ b/test/lib/work_hours_calculator/parser_test.rb
@@ -57,6 +57,9 @@ class WorkHoursCalculator::ParserTest < Minitest::Test
           -b, --breaks x,y                 Break periods as comma-separated pairs (e.g., '12:49:00 PM-1:26:00 PM,3:42:00 PM-4:35:00 PM')
               --csv-input FILE             CSV input file
               --csv-output FILE            CSV output file
+              --log DESCRIPTION            Log work with description
+              --log-dir DIRECTORY          Directory to store log files
+              --calculate-log DATE         Calculate hours from the log file for the specified date (e.g., '2023-10-01')
           -h, --help                       Show help
     HELP
 

--- a/test/lib/work_hours_calculator/parser_test.rb
+++ b/test/lib/work_hours_calculator/parser_test.rb
@@ -48,6 +48,20 @@ class WorkHoursCalculator::ParserTest < Minitest::Test
     end
   end
 
+  def test_parse_options_with_log_description
+    args = ["--log", "Started work on feature X"]
+    options = WorkHoursCalculator::Parser.parse_options(args)
+    assert_equal "Started work on feature X", options[:description]
+    assert options[:log]
+  end
+
+  def test_parse_options_with_calculate_log
+    args = ["--calculate-log", "2025-02-01"]
+    options = WorkHoursCalculator::Parser.parse_options(args)
+    assert_equal "2025-02-01", options[:log_date]
+    assert options[:calculate_log]
+  end
+
   def test_parse_options_help_display
     args = ["-h"]
     expected_output = <<~HELP

--- a/test/lib/work_hours_calculator_test.rb
+++ b/test/lib/work_hours_calculator_test.rb
@@ -2,7 +2,7 @@ require_relative "../test_helper"
 require "minitest/autorun"
 require_relative "../../lib/work_hours_calculator"
 
-class WorkHoursCalculatorTest < Minitest::Test
+class WorkHoursCalculatorCalculateTest < Minitest::Test
   def setup
     @work_start = "9:00 AM"
     @work_end = "5:00 PM"
@@ -38,5 +38,26 @@ class WorkHoursCalculatorTest < Minitest::Test
     result = WorkHoursCalculator.calculate(@work_start, @work_end, [["12:00 PM", "2:00 PM"]])
     assert_in_delta 6.0, result[:net_work_decimal_hours], 0.01
     assert_equal "2:00", result[:total_break_hours]
+  end
+
+  def test_calculate_hours_from_log
+    result = {
+      work_start: "9:00:00 AM",
+      work_end: "5:00:00 PM",
+      breaks: [["12:00:00 PM", "1:00:00 PM"]]
+    }
+    WorkHoursCalculator::Logger.stub(:get_hours_from_log, result) do
+      hours = WorkHoursCalculator.calculate_hours_from_log(Date.today)
+      assert_in_delta 8.0, hours[:total_work_decimal_hours], 0.01
+      assert_in_delta 1.0, hours[:total_break_decimal_hours], 0.01
+      assert_in_delta 7.0, hours[:net_work_decimal_hours], 0.01
+      assert_equal "1:00", hours[:total_break_hours]
+    end
+  end
+
+  def test_fail_calculate_hours_from_log
+    assert_raises(WorkHoursCalculator::InvalidRecord) do
+      WorkHoursCalculator.calculate_hours_from_log(nil)
+    end
   end
 end

--- a/work_hours_calculator.gemspec
+++ b/work_hours_calculator.gemspec
@@ -38,4 +38,14 @@ Gem::Specification.new do |spec|
   spec.add_dependency "csv", "~> 3.1"
   spec.add_dependency "mutex_m", "~> 0.1.0"
   spec.add_development_dependency "minitest", "~> 5.14"
+  spec.post_install_message = <<~POST_INSTALL
+    Thank you for installing the Work Hours Calculator gem!
+    
+    You can set the log directory using the WORK_HOURS_LOG_DIR environment variable. If this variable is not set, the default log directory will be ~/work_hours_logs.
+    
+    Example:
+      export WORK_HOURS_LOG_DIR="/path/to/custom/log_directory"
+    
+    For more information, please refer to the README.md file.
+  POST_INSTALL
 end


### PR DESCRIPTION
# Summary

We are adding an ability for a user to log his time in a csv file. This is much like a daily work dairy where the file will be created based on the date that the work log has been created (e.g 2025-02-14, 2025-02-15, etc). The calculator will be able to calculate the total work and break hours for the day by identifying a keyword in the description:
- "break" when logged as a break
- "end" when logged as end of work for the day

## Type of change

Please delete options that are not relevant.

- [x] New feature (non-breaking change which adds functionality)
- [ ] This change requires a documentation update

## How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration.

- [ ] Test A
- [ ] Test B

## Unit tests

**Unit tests are required for all changes. Please confirm that you have added or modified unit tests to verify your changes:**

- [ ] Yes, I have added or modified unit tests.
- [ ] No, I have not added or modified unit tests.

If yes, please describe the tests that you added or modified:

- **Test Name:** Description of what the test does.
- **Test Name:** Description of what the test does.

## Checklist:

- [ ] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules