### PR TITLE
Add more option keys for some commands and more information

### DIFF
--- a/README.md
+++ b/README.md
@@ -87,11 +87,11 @@ Run the script from the command line with the required options for start time, e
 | -s or --start-time | Specifies the work start time | `-s "9:30:00 AM"` |
 | -e or --end-time | Specifies the work end time | `-e "6:00:00 PM"` |
 | -b or --breaks | Specifies break periods in comma-separated start_time-end_time format | `-b "12:49:00 PM-1:26:00 PM,3:42:00 PM-4:35:00 PM"` |
-| --csv-input | Specifies the CSV input file | `--csv-input path/to/your/input.csv`s |
-| --csv-output | Specifies the CSV output file | `--csv-output path/to/your/output.csv` |
-| --log DESCRIPTION | Log work with description | `--log "working on a project"` |
-| --log-dir DIRECTORY | Specify a directory to store log files | `--lod-dir` <br><br>or export it as an ENV variable so you don't have to specify the directory arg everytime. <br> `export WORK_HOURS_LOG_DIR="/some/path"`|
-| --calculate-log DATE | Calculate hours from the log file for the specified date (e.g., '2023-10-01') | `--calculate-log 2025-02-01` |
+| -i, --csv-input | Specifies the CSV input file | `--csv-input path/to/your/input.csv`s |
+| -o, --csv-output | Specifies the CSV output file | `--csv-output path/to/your/output.csv` |
+| -l, --log DESCRIPTION | Log work with description | `--log "working on a project"` |
+| -dir, --log-dir DIRECTORY | Specify a directory to store log files | `--lod-dir` <br><br>or export it as an ENV variable so you don't have to specify the directory arg everytime. <br> `export WORK_HOURS_LOG_DIR="/some/path"`|
+| -t, --calculate-log DATE | Calculate hours from the log file for the specified date (e.g., '2023-10-01') | `--calculate-log 2025-02-01` |
 | -h or --help | Displays help instructions | `-h` |
 
 

--- a/lib/work_hours_calculator/parser.rb
+++ b/lib/work_hours_calculator/parser.rb
@@ -4,43 +4,75 @@ require "optparse"
 
 # Parses command-line options for the work calculator.
 module WorkHoursCalculator
+  class ParserError < StandardError; end
+
+  class MissingOptionError < ParserError; end
+
+  class InvalidOptionError < ParserError; end
+
   class Parser
     def self.parse_options(args = ARGV)
       options = {}
       OptionParser.new do |opts|
-        opts.banner = "Usage: work_calculator.rb [options]"
+        opts.banner = "Usage: work_calculator [options] arg"
 
+        opts.separator ""
+        opts.separator "General Options:"
         opts.on("-s", "--start-time START", "Work start time (e.g., '9:30:00 AM')") { |v| options[:start_time] = v }
         opts.on("-e", "--end-time END", "Work end time (e.g., '6:00:00 PM')") { |v| options[:end_time] = v }
         opts.on("-b", "--breaks x,y", Array, "Break periods as comma-separated pairs (e.g., '12:49:00 PM-1:26:00 PM,3:42:00 PM-4:35:00 PM')") { |v| options[:breaks] = v.map { |pair| pair.split("-") } }
-        opts.on("--csv-input FILE", "CSV input file") { |v| options[:csv_input] = v }
-        opts.on("--csv-output FILE", "CSV output file") { |v| options[:csv_output] = v }
-        opts.on("--log DESCRIPTION", "Log work with description") { |v|
+
+        opts.separator ""
+        opts.separator "CSV File Options:"
+        opts.on("-i", "--csv-input FILE", "CSV input file") { |v| options[:csv_input] = v }
+        opts.on("-o", "--csv-output FILE", "CSV output file") { |v| options[:csv_output] = v }
+
+        opts.separator ""
+        opts.separator "Work hour logging Options:"
+        opts.on("-l", "--log DESCRIPTION", "Log work with description") { |v|
           options[:log] = true
           options[:description] = v
         }
-        opts.on("--log-dir DIRECTORY", "Directory to store log files") { |v| options[:log_dir] = v }
-        opts.on("--calculate-log DATE", "Calculate hours from the log file for the specified date (e.g., '2023-10-01')") { |v|
+        opts.on("--dir DIRECTORY", "Directory to store log files") { |v| options[:log_dir] = v }
+        opts.on("-t", "--calculate-log DATE", "Calculate hours from the log file for the specified date (e.g., '2023-10-01')") { |v|
           options[:calculate_log] = true
           options[:log_date] = v
         }
+
+        opts.separator ""
+        opts.separator "Setup your log directory via environment variable:"
+        opts.separator ""
+        opts.separator "export WORK_HOURS_LOG_DIR='/some/path'"
+
+        opts.separator ""
+        opts.separator ""
+        opts.separator "For more information:"
         opts.on("-h", "--help", "Show help") {
           puts opts
           exit
         }
+
+        opts.separator ""
+        opts.separator "=============================================="
+        opts.separator ""
+        opts.separator "Thank you for supporting open source projects."
+        opts.separator "For bugs or feature requests, visit https://github.com/gerdadecio/work-hours-calculator-ruby"
+        opts.separator "Author: Gerda Decio, https://github.com/gerdadecio"
       end.parse!(args, into: options)
 
       if (options[:csv_input].nil? && options[:log].nil? && options[:calculate_log].nil?) && (options[:start_time].nil? || options[:end_time].nil? || options[:breaks].nil?)
-        puts "Please provide start time, end time, and break times, or a CSV input file."
-        exit
+        raise MissingOptionError, "Please provide start time, end time, and break times, or a CSV input file."
       end
 
       if options[:log] && options[:description].nil?
-        puts "Error: Description is required when logging work hours."
-        exit 1
+        raise MissingOptionError, "Description is required when logging work hours."
       end
 
       options
+    rescue OptionParser::MissingArgument, WorkHoursCalculator::MissingOptionError => e
+      puts e.message
+      puts "\nfor more information: work_calculator --help"
+      exit
     end
   end
 end

--- a/test/lib/work_hours_calculator/parser_test.rb
+++ b/test/lib/work_hours_calculator/parser_test.rb
@@ -5,6 +5,12 @@ require "minitest/autorun"
 require_relative "../../../lib/work_hours_calculator/parser"
 
 class WorkHoursCalculator::ParserTest < Minitest::Test
+  def test_parse_options_invalid_option
+    assert_raises(OptionParser::InvalidOption) do
+      WorkHoursCalculator::Parser.parse_options(["--invalid-option"])
+    end
+  end
+
   def test_parse_options_with_all_arguments
     args = ["-s", "9:30:00 AM", "-e", "6:00:00 PM", "-b", "12:00 PM-12:30 PM,3:00 PM-3:15 PM"]
     options = WorkHoursCalculator::Parser.parse_options(args)
@@ -52,6 +58,21 @@ class WorkHoursCalculator::ParserTest < Minitest::Test
   def test_parse_options_missing_required_arguments
     args = []
     assert_output(/Please provide start time, end time, and break times, or a CSV input file./) do
+      assert_raises(SystemExit) { WorkHoursCalculator::Parser.parse_options(args) }
+    end
+  end
+
+  def test_parse_options_valid_log_options
+    args = ["--log", "Started working on project X", "--dir", "im-a-path"]
+    options = WorkHoursCalculator::Parser.parse_options(args)
+    assert options[:log]
+    assert_equal "Started working on project X", options[:description]
+    assert_equal "im-a-path", options[:log_dir]
+  end
+
+  def test_parse_options_missing_description
+    args = ["--log"]
+    assert_output(/missing argument: --log/) do
       assert_raises(SystemExit) { WorkHoursCalculator::Parser.parse_options(args) }
     end
   end

--- a/test/lib/work_hours_calculator/parser_test.rb
+++ b/test/lib/work_hours_calculator/parser_test.rb
@@ -26,17 +26,25 @@ class WorkHoursCalculator::ParserTest < Minitest::Test
     args = ["--csv-input", "input.csv"]
     options = WorkHoursCalculator::Parser.parse_options(args)
     assert_equal "input.csv", options[:csv_input]
+
+    args = ["-i", "input.csv"]
+    options = WorkHoursCalculator::Parser.parse_options(args)
+    assert_equal "input.csv", options[:csv_input]
   end
 
   def test_parse_options_with_csv_output
     args = ["-s", "9:00 AM", "-e", "5:00 PM", "-b", "12:00 PM-12:30 PM,3:00 PM-3:15 PM", "--csv-output", "output.csv"]
     options = WorkHoursCalculator::Parser.parse_options(args)
     assert_equal "output.csv", options[:csv_output]
+
+    args = ["-s", "9:00 AM", "-e", "5:00 PM", "-b", "12:00 PM-12:30 PM,3:00 PM-3:15 PM", "-o", "output.csv"]
+    options = WorkHoursCalculator::Parser.parse_options(args)
+    assert_equal "output.csv", options[:csv_output]
   end
 
   def test_parse_options_with_help
     args = ["-h"]
-    assert_output(/Usage: work_calculator.rb \[options\]/) do
+    assert_output(/Usage: work_calculator \[options\] arg/) do
       assert_raises(SystemExit) { WorkHoursCalculator::Parser.parse_options(args) }
     end
   end
@@ -60,21 +68,45 @@ class WorkHoursCalculator::ParserTest < Minitest::Test
     options = WorkHoursCalculator::Parser.parse_options(args)
     assert_equal "2025-02-01", options[:log_date]
     assert options[:calculate_log]
+
+    args = ["-t", "2025-02-01"]
+    options = WorkHoursCalculator::Parser.parse_options(args)
+    assert_equal "2025-02-01", options[:log_date]
+    assert options[:calculate_log]
   end
 
   def test_parse_options_help_display
     args = ["-h"]
     expected_output = <<~HELP
-      Usage: work_calculator.rb [options]
+      Usage: work_calculator [options] arg
+
+      General Options:
           -s, --start-time START           Work start time (e.g., '9:30:00 AM')
           -e, --end-time END               Work end time (e.g., '6:00:00 PM')
           -b, --breaks x,y                 Break periods as comma-separated pairs (e.g., '12:49:00 PM-1:26:00 PM,3:42:00 PM-4:35:00 PM')
-              --csv-input FILE             CSV input file
-              --csv-output FILE            CSV output file
-              --log DESCRIPTION            Log work with description
-              --log-dir DIRECTORY          Directory to store log files
-              --calculate-log DATE         Calculate hours from the log file for the specified date (e.g., '2023-10-01')
+      
+      CSV File Options:
+          -i, --csv-input FILE             CSV input file
+          -o, --csv-output FILE            CSV output file
+
+      Work hour logging Options:
+          -l, --log DESCRIPTION            Log work with description
+              --dir DIRECTORY              Directory to store log files
+          -t, --calculate-log DATE         Calculate hours from the log file for the specified date (e.g., '2023-10-01')
+
+      Setup your log directory via environment variable:
+
+      export WORK_HOURS_LOG_DIR='/some/path'
+
+
+      For more information:
           -h, --help                       Show help
+
+      ==============================================
+
+      Thank you for supporting open source projects.
+      For bugs or feature requests, visit https://github.com/gerdadecio/work-hours-calculator-ruby
+      Author: Gerda Decio, https://github.com/gerdadecio
     HELP
 
     assert_output(expected_output) do


### PR DESCRIPTION
# Summary

Add in alternative/shorter option key for the following commands:
- csv input/output
- log 
- calculate
- directory (breaking change)

## Type of change

Please delete options that are not relevant.

- [x] Breaking change (replaced the `--log-dir` option with shorter version `--dir`)

## Unit tests

**Unit tests are required for all changes. Please confirm that you have added or modified unit tests to verify your changes:**

- [x] Yes, I have added or modified unit tests.

If yes, please describe the tests that you added or modified:
- updated the` parser_test.rb` to cover the change

## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] Any dependent changes have been merged and published in downstream modules