### PR TITLE
Default to current day

### DIFF
--- a/lib/work_hours_calculator/logger.rb
+++ b/lib/work_hours_calculator/logger.rb
@@ -39,8 +39,8 @@ module WorkHoursCalculator
       puts "Logged work: #{Time.now.strftime("%Y-%m-%d %H:%M:%S")} - #{description}"
     end
 
-    def self.get_hours_from_log(date, log_dir = DEFAULT_LOG_DIR)
-      raise InvalidRecord, "Date cannot be nil" if date.nil?
+    def self.get_hours_from_log(date = Date.today, log_dir = DEFAULT_LOG_DIR)
+      date ||= Date.today
 
       log_file = File.join(log_dir, "#{date}.csv")
       unless File.exist?(log_file)

--- a/test/lib/work_hours_calculator/logger_test.rb
+++ b/test/lib/work_hours_calculator/logger_test.rb
@@ -109,4 +109,19 @@ class WorkHoursCalculator::LoggerTest < Minitest::Test
     assert_equal "05:00:00 PM", result[:work_end]
     assert_equal 0, result[:breaks].size
   end
+
+  def test_get_hours_from_log_uses_current_date
+    FileUtils.mkdir_p(@log_dir)
+    log_file = File.join(@log_dir, "#{Date.today}.csv")
+    CSV.open(log_file, "w") do |csv|
+      csv << ["2025-02-01 09:00:00", "Started working"]
+      csv << ["2025-02-01 17:00:00", "End"]
+    end
+
+    result = WorkHoursCalculator::Logger.get_hours_from_log(nil, @log_dir)
+
+    assert_equal "09:00:00 AM", result[:work_start]
+    assert_equal "05:00:00 PM", result[:work_end]
+    assert_equal 0, result[:breaks].size
+  end
 end

--- a/test/lib/work_hours_calculator_test.rb
+++ b/test/lib/work_hours_calculator_test.rb
@@ -54,10 +54,4 @@ class WorkHoursCalculatorCalculateTest < Minitest::Test
       assert_equal "1:00", hours[:total_break_hours]
     end
   end
-
-  def test_fail_calculate_hours_from_log
-    assert_raises(WorkHoursCalculator::InvalidRecord) do
-      WorkHoursCalculator.calculate_hours_from_log(nil)
-    end
-  end
 end


### PR DESCRIPTION
# Summary

`get_hours_from_log` method will now default to the current day rather than raising an error when no date is passed.

## Type of change

Please delete options that are not relevant.

- [x] New feature (non-breaking change which adds functionality)

## Unit tests

**Unit tests are required for all changes. Please confirm that you have added or modified unit tests to verify your changes:**

- [x] Yes, I have added or modified unit tests.

If yes, please describe the tests that you added or modified:

- Update the `logger_test.rb` to cover the change

## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] Any dependent changes have been merged and published in downstream modules